### PR TITLE
Adding update and delete to auction item

### DIFF
--- a/server/src/com/scraniel/auctioneero/AuctionManager.java
+++ b/server/src/com/scraniel/auctioneero/AuctionManager.java
@@ -9,78 +9,57 @@ import org.hibernate.cfg.NotYetImplementedException;
 import com.scraniel.auctioneero.hbm.*;
 import com.scraniel.auctioneero.tables.*;
 
-// How the user interacts with various auction objects
+/**
+ * Will be the interface used by the REST API to interact with objects in the database.
+ * @author Danny Lewis
+ *
+ */
 public class AuctionManager 
 {
-	
-	// Attempts to add a new bid on an item.
-	// IDEA: * Lock the item row
-	//		 * Check the price, abort if too high
-	//		 * Update the item
-	//		 * Unlock the row
-	// This will be implemented once we have MySQL.
-	// Should be safe against SQL injection as we force typing
+	/**
+	 *  Attempts to add a new bid on an item.
+	 *  IDEA:	* Lock the item row
+	 *		 	* Check the price, abort if too high
+	 *		 	* Update the item
+	 *		 	* Unlock the row
+	 * @param itemId The item to bid on
+	 * @param bidderId The bidder
+	 * @param bid The new bid
+	 * @return
+	 */
 	public AuctionResponse bidOnItem(UUID itemId, UUID bidderId, float bid)
-	{		
-		int currentBid = 0;
-		String message = null;
-		boolean isSuccessfulBid = true;
-		Timestamp expiry = null;
-		Timestamp now = new Timestamp(System.currentTimeMillis());
+	{
+		// We need to open our own session so we can load the item
+		//
+		Session session = HibernateContext.getInstance().getSessionFactory().openSession();
 		
 		// 1. Lock the item row
 		// BEGIN;
 		// SELECT * FROM items WHERE item_id = '{itemId}' FOR UPDATE;
 		//
-		HibernateContext context = HibernateContext.getInstance();
-		SessionFactory sessionFactory = context.getSessionFactory();
+		AuctionItem item = session.load(AuctionItem.class, itemId, LockOptions.UPGRADE);
+		item.setCurrentSession(session);
 		
-		Session session = sessionFactory.openSession();
-		Transaction transaction = null;
-		
-		session.load(AuctionItem.class, itemId, LockOptions.UPGRADE);
-		
-		
-		// 2. Check the expiry and price, abort if too high. Don't want to do fully in SQL so we can return current bid
-		//
-		// TODO: Get Date.Now() for comparison
-		//
-		if(now.after(expiry))
-		{
-			isSuccessfulBid = false;
-			message = String.format("Your bid of %f could not be made; auction expired on %f", bid, expiry);
-		}
-		
-		if(currentBid >= bid)
-		{
-			// TODO: Extract messages to config
-			//
-			isSuccessfulBid = false;
-			message = String.format("Your bid of %f could not be made; the current high bid is %f", bid, currentBid);
-			
-			// 2.1. Unlock the row
-			// END;
-			//
-		}
-		else
-		{
-			// 3. Update the item, unlock
-			// Look up SQL for this, probably UPDATE or ALTER
-			// END;
-			//
-			message = String.format("Your bid of %f is the new highest bid", bid);
-		}
-		
-		throw new NotYetImplementedException();
+		return item.bidOn(bid, bidderId);
 	}
 	
-	// Puts a new item up for auction; do we care about conflicts? Probably not, maybe within user's own items
-	// Need to scrub name parameter to protect against injection
+	/**
+	 * Puts a new item up for auction.
+	 * NOTES: - do we care about conflicts? Probably not, maybe within user's own items
+	 * 		  -	Hibernate is quite safe in terms of SQL injection, parameterizes everything
+	 * @param name The name of the item
+	 * @param description A description of the item
+	 * @param userId The user putting the item up for auction
+	 * @param startingBid The value to start the bidding at
+	 * @param expiry When the auction expires
+	 * @return
+	 */
 	public AuctionResponse addItem(String name, String description, UUID userId, float startingBid, Timestamp expiry)
 	{
 		// 1. Get user's items, make sure there are none with same name (this step is possibly unnecessary, and for now is skipped)
 		// Something like:
 		// SELECT count(*) FROM items WHERE user_id = '{userId}' and name = {name}
+		//
 		AuctionItem item = new AuctionItem();
 		UUID id = UUID.randomUUID();
 		item.setId(id);
@@ -95,12 +74,23 @@ public class AuctionManager
 		return item.insert();
 	}
 	
-	// Removes an item currently up for auction
+	/**
+	 * Removes an item currently up for auction
+	 * TODO: Eventually should add an event that fires when this happens so we can inform bidders
+	 *  
+	 * @param itemId Item to cancel
+	 * @return AuctionResponse containing either an error successful delete message
+	 */
 	public AuctionResponse cancelAuction(UUID itemId)
 	{
-		throw new NotYetImplementedException();
+		// We need to open our own session so we can load the item
+		//
+		Session session = HibernateContext.getInstance().getSessionFactory().openSession();
+		AuctionItem item = session.load(AuctionItem.class, itemId);
+		item.setCurrentSession(session);
+		
+		return item.delete();
 	}
-	
 	
 	/**
 	 * Adds a new user. Currently we don't use username as primary key, think about changing this.
@@ -120,5 +110,4 @@ public class AuctionManager
 		
 		return newUser.insert();
 	}
-	
 }

--- a/server/src/com/scraniel/auctioneero/Bootstrapper.java
+++ b/server/src/com/scraniel/auctioneero/Bootstrapper.java
@@ -23,9 +23,23 @@ public class Bootstrapper
 			
 			// Test adding
 			AuctionResponse response =  manager.addUser("Calimbo");
+			UUID ownerId = response.getId();
+			response =  manager.addUser("Jimmy");
+			UUID bidderId = response.getId();
 			if(response.isActionSuccess())
 			{
-				manager.addItem("Cool Item 2", "This item is so, so, SO cool", response.getId(), 32.32f, new Timestamp(100000));
+				response = manager.addItem("Cool Item 3", "This item is neat", ownerId, 33.32f, new Timestamp(System.currentTimeMillis() + 100000));
+				
+				if(response.isActionSuccess())
+				{
+					response = manager.bidOnItem(response.getId(), bidderId, 30);
+					
+					System.out.println(response.getOutputMessage());
+					
+					response = manager.cancelAuction(response.getId());
+					
+					System.out.println(response.getOutputMessage());
+				}
 			}
 		}
 		catch(Exception e)

--- a/server/src/com/scraniel/auctioneero/hbm/HibernateContext.java
+++ b/server/src/com/scraniel/auctioneero/hbm/HibernateContext.java
@@ -57,11 +57,10 @@ public class HibernateContext
 	 * 
 	 * Will catch exceptions rollback if required. 
 	 * @param toExecute The sql statement to execute.
-	 * @return AuctionResponse with success message + ID or error mesage.
+	 * @return AuctionResponse with success message + ID or error message.
 	 */
-	public AuctionResponse executeSqlStatement(HibernateSqlStatement toExecute)
+	public AuctionResponse executeSqlStatement(HibernateSqlStatement toExecute, Session session)
 	{		
-		Session session = sessionFactory.openSession();
 		Transaction transaction = null;
 		AuctionResponse response;
 		
@@ -86,6 +85,16 @@ public class HibernateContext
 		}
 		
 		return response;
+	}
+	
+	/**
+	 * 
+	 * @param toExecute
+	 * @return
+	 */
+	public AuctionResponse executeSqlStatement(HibernateSqlStatement toExecute)
+	{		
+		return executeSqlStatement(toExecute, sessionFactory.openSession());
 	}
 	
 	/**

--- a/server/src/com/scraniel/auctioneero/hbm/HibernateTable.java
+++ b/server/src/com/scraniel/auctioneero/hbm/HibernateTable.java
@@ -17,6 +17,11 @@ public abstract class HibernateTable
 	@Column(name = "id", length = 36)
 	protected UUID id;
 	
+	// The session used to retrieve this object
+	//
+	@Transient
+	protected Session currentSession;
+	
 	public UUID getId() 
 	{
 		return id;
@@ -27,8 +32,18 @@ public abstract class HibernateTable
 		this.id = id;
 	}
 	
+	public Session getCurrentSession() 
+	{
+		return currentSession;
+	}
+	
+	public void setCurrentSession(Session currentSession) 
+	{
+		this.currentSession = currentSession;
+	}
+	
 	/**
-	 * Returns an informational message when this object gets inserted to it's table
+	 * Returns an informational message when this object gets inserted to its table
 	 * 
 	 * TODO: May want to have these format string (among other strings) to a config file
 	 * 
@@ -37,13 +52,23 @@ public abstract class HibernateTable
 	protected abstract String getSuccessfulInsertMessage();
 	
 	/**
-	 * Performs a simple insert of the current object (ie. start transaction, save, commit transaction
+	 * Returns an informational message when this object gets deleted from its table
+	 * 
+	 * TODO: May want to have these format string (among other strings) to a config file
+	 * 
+	 * @return String with informational message upon successful delete
+	 */
+	protected abstract String getSuccessfulDeleteMessage();
+	
+	/**
+	 * Performs a simple insert of the current object (ie. start transaction, save, commit transaction)
 	 * 
 	 * @return AuctionResponse object either containing error or the UUID of the newly inserted object
 	 */
 	public AuctionResponse insert()
 	{
 		// Required so anonymous class uses subclass instead of parent
+		//
 		HibernateTable current = this;
 		
 		HibernateSqlStatement statement = new HibernateSqlStatement()
@@ -59,5 +84,31 @@ public abstract class HibernateTable
 		
 		return HibernateContext.getInstance().executeSqlStatement(statement);
 	}
-
+	
+	/**
+	 * Performs a simple delete of the current object (ie. start transaction, delete, commit transaction)
+	 * Should only be called with a persistent instance (if you have not-null columns, cannot delete from 
+	 * transient instance)
+	 * 
+	 * @return AuctionResponse object either containing error or the successful delete message
+	 */
+	public AuctionResponse delete()
+	{
+		// Required so anonymous class uses subclass instead of parent
+		//
+		HibernateTable current = this;
+		
+		HibernateSqlStatement statement = new HibernateSqlStatement()
+		{			
+			@Override
+			public AuctionResponse execute(Session session) throws HibernateException
+			{
+				session.delete(current);
+				
+				return new AuctionResponse(true, getSuccessfulDeleteMessage(), null);
+			}
+		};
+		
+		return HibernateContext.getInstance().executeSqlStatement(statement, currentSession);
+	}
 }

--- a/server/src/com/scraniel/auctioneero/tables/AuctionItem.java
+++ b/server/src/com/scraniel/auctioneero/tables/AuctionItem.java
@@ -8,8 +8,14 @@ import javax.persistence.Entity;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 
+import org.hibernate.HibernateException;
+import org.hibernate.LockOptions;
+import org.hibernate.Session;
 import org.hibernate.annotations.Type;
 
+import com.scraniel.auctioneero.AuctionResponse;
+import com.scraniel.auctioneero.hbm.HibernateContext;
+import com.scraniel.auctioneero.hbm.HibernateSqlStatement;
 import com.scraniel.auctioneero.hbm.HibernateTable;
 
 @Entity
@@ -35,6 +41,7 @@ public class AuctionItem extends HibernateTable
 	private UUID highBidderId;
 	
 	// We use custom getter setter to store as VARCHAR (see getCategoryString / setCategoryString)
+	@Transient
 	private Category category;
 	
 	@Column(name = "expiry", nullable = false)
@@ -130,4 +137,72 @@ public class AuctionItem extends HibernateTable
 		return String.format("The item '%s' has been added with initial bid %.2f", name, currentBid);
 	}
 	
+	@Override
+	protected String getSuccessfulDeleteMessage() 
+	{
+		return "Item deleted successfully.";
+	}
+	
+	/**
+	 * Bids on an item. Should only be called with a persistent instance.
+	 * 
+	 * @param bid The new bid for the item
+	 * @param bidderId The bidder
+	 * @return
+	 */
+	public AuctionResponse bidOn(float bid, UUID bidderId)
+	{
+		if(currentSession == null)
+		{
+			// TODO: Should be exception
+			//
+			return new AuctionResponse(false, "Need persistent instance", null);
+		}
+		
+		HibernateSqlStatement statement = new HibernateSqlStatement()
+		{
+			@Override
+			public AuctionResponse execute(Session session) throws HibernateException
+			{
+				String message = null;
+				boolean isSuccessfulBid = true;
+				Timestamp now = new Timestamp(System.currentTimeMillis());
+				
+				// 2. Check the expiry and price, abort if too high. Don't want to do fully in SQL so we can return current bid
+				//
+				if(now.after(getExpiry()))
+				{
+					isSuccessfulBid = false;
+					message = String.format("Your bid of %f could not be made; auction expired on %f", bid, getExpiry());
+				}
+				else if(getCurrentBid() >= bid)
+				{
+					// TODO: Extract messages to config
+					//
+					isSuccessfulBid = false;
+					message = String.format("Your bid of %f could not be made; the current high bid is %f", bid, getCurrentBid());
+					
+					// 2.1. Unlock the row
+					// END;
+					//
+				}
+				else
+				{
+					// 3. Update the item, unlock
+					// END;
+					//
+					// Note that since we used session.load, the item is in a persistent state and is tied to the session. Thus,
+					// the item will be persisted as soon as the transaction is committed, no save / merge / update necessary.
+					//
+					setCurrentBid(bid);
+					setHighBidderId(bidderId);
+					message = String.format("Your bid of %f is the new highest bid", bid);
+				}	
+				
+				return new AuctionResponse(isSuccessfulBid, message, getId());
+			}
+		};
+		
+		return HibernateContext.getInstance().executeSqlStatement(statement, currentSession); 
+	}
 }

--- a/server/src/com/scraniel/auctioneero/tables/User.java
+++ b/server/src/com/scraniel/auctioneero/tables/User.java
@@ -28,4 +28,10 @@ public class User extends HibernateTable
 	{
 		return String.format("The user '%s' has been successfully added", userName);
 	}
+	
+	@Override
+	protected String getSuccessfulDeleteMessage() 
+	{
+		return "User deleted successfully.";
+	}
 }


### PR DESCRIPTION
Adds add and update to auction item, nothing too huge. Moved update logic into the actual item code, sticking with the paradigm of having the auction manager set up the objects, then having the objects themselves deal with the logic. The HibernateContext handles the execution of the queries, as this is common to all of them. The only thing that can differ is opening the session, which sometimes will happen outside if a persistent instance is required (ie. for bidding on or deleting the item)